### PR TITLE
Add calculate.html, Modify main.py

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ def student():
 @app.route('/detail', methods = ['POST', 'GET'])
 def detail():
    if request.method == 'POST':
+      global detail
       detail = dict()
       detail['Name'] = request.form.get('Name')
       detail['StudentNumber'] = request.form.get('StudentNumber')
@@ -20,11 +21,24 @@ def detail():
 def result():
    if request.method == 'POST':
       result = dict()
-      result['Name'] = request.form.get('Name')
-      result['StudentNumber'] = request.form.get('StudentNumber')
-      result['Gender'] = request.form.get('Gender')
-      result['Major'] = request.form.get('Major')
+      # result['Name'] = request.form.get('Name')
+      # result['StudentNumber'] = request.form.get('StudentNumber')
+      # result['Gender'] = request.form.get('Gender')
+      # result['Major'] = request.form.get('Major')
+      result['Name'] = detail['Name']
+      result['StudentNumber'] = detail['StudentNumber']
+      result['Gender'] = detail['Gender']
+      result['Major'] = detail['Major']
+      college = request.form.get('College')
+      if(college == '불교대학'): total = 4000000
+      elif(college == '문과대학'): total = 4200000
+      else: total = 4500000
+      result['Tuition'] = format(int(total * (1 - int(request.form.get('Scholarship'))/100)), ',d')
       return render_template("result.html",result = result)
+
+@app.route('/calculate')
+def calculate():
+   return render_template('calculate.html')
 
 if __name__ == '__main__':
    app.run(host="0.0.0.0", debug=True, port=80)

--- a/app/templates/calculate.html
+++ b/app/templates/calculate.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+   <body>
+   
+      <form action = "/result" method = "POST">
+         <p>소속 단과대</p>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="불교대학"/>불교대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="문과대학"/>문과대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="이과대학"/>이과대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="법과대학"/>법과대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="사회과학대학"/>사회과학대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="경찰사법대학"/>경찰사법대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="경영대학"/>경영대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="바이오시스템대학"/>바이오시스템대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="공과대학"/>공과대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="사범대학"/>사범대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="예술대학"/>예술대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="약학대학"/>약학대학</label>
+            <label><input type="radio" style="vertical-align: top;" name="College" value="미래융합대학"/>미래융합대학</label>
+
+            <!-- <label><input type="radio" name="College" value="BuddhistStudies"/>BuddhistStudies</label>
+            <label><input type="radio" name="College" value="Humanities"/>Humanities</label>
+            <label><input type="radio" name="College" value="NaturalScience"/>NaturalScience</label>
+            <label><input type="radio" name="College" value="Law"/>Law</label>
+            <label><input type="radio" name="College" value="SocialScience"/>SocialScience</label>
+            <label><input type="radio" name="College" value="PoliceAndCriminalJustice"/>PoliceAndCriminalJustice</label>
+            <label><input type="radio" name="College" value="Business"/>Business</label>
+            <label><input type="radio" name="College" value="LifeScienceAndBiotechnology"/>LifeScienceAndBiotechnology</label>
+            <label><input type="radio" name="College" value="Engineering"/>Engineering</label>
+            <label><input type="radio" name="College" value="Education"/>Education</label>
+            <label><input type="radio" name="College" value="Arts"/>Arts</label>
+            <label><input type="radio" name="College" value="Pharmacy"/>Pharmacy</label>
+            <label><input type="radio" name="College" value="AppliedConvergency"/>AppliedConvergency</label> -->
+         <p>장학금 퍼센티지 <input type = "text" name = "Scholarship" /></p>
+
+         <p><input type = "submit" value = "SUBMIT" /></p>
+         <!-- <input type = "button" value = "SUBMIT" onclick="location.href='result'"/> -->
+      </form>
+      
+   </body>
+</html>

--- a/app/templates/detail.html
+++ b/app/templates/detail.html
@@ -16,7 +16,7 @@
       <table border = 0>
         <tr>
            <td> <p><input type = "button" value = "MODIFY" onclick = "history.go(-1)"/></p> </td>
-           <td> <p><input type = "button" value = "CALCULATE" onclick="location.href='calculation.html'"/></p> </td>
+           <td> <p><input type = "button" value = "CALCULATE" onclick="location.href='calculate'"/></p> </td>
         </tr>
         
       </table>


### PR DESCRIPTION
계산 화면인 calculate.html 파일을 추가하였습니다.
경로는 /calculate로 설정하였습니다.
![image](https://user-images.githubusercontent.com/78717113/143778305-e477e52e-4197-4d5e-a8a1-8f2686866746.png)

소속 단과대학 선택 및 장학금 퍼센티지 입력을 한글로 설정해두었는데
혹시 영어로 통일해야 할 경우를 대비해 소스코드에 영어로 설정된 부분도
추가하여 주석처리 해두었습니다.

단과대별 납부해야될 장학금의 경우 정확한 정보가 아직 없어서
임시로 불교대, 문과대, 그 외로 나누어 설정해두었고
result 페이지의 tuition 항목에서 계산 결과를 확인할 수 있도록 하였습니다.

result 페이지에 결과를 가져오는 기존 코드의 경우
새로운 계산 페이지가 추가됨에 따라 바로 정보를 불러올 수 없게 되어
detail화면에 나타난 정보들이 저장된 detail 딕셔너리를 전역변수로 설정하여
result 페이지에서 불러올 수 있도록 하였습니다.

혹시 result 페이지 담당하신 분이 더 나은 방법을 찾아주신다면
개선해보는 것도 좋을 것 같습니다!